### PR TITLE
Update 0053-sdk3-crud.md

### DIFF
--- a/rfc/0053-sdk3-crud.md
+++ b/rfc/0053-sdk3-crud.md
@@ -519,6 +519,7 @@ Throws
 
   - DocumentNotFoundException (#105)
   - DocumentExistsException (#101)
+  - CasMismatchException (#9)
   - RequestTimeoutException (#1)
   - SubdocException (#126)
   - CouchbaseException (#0)


### PR DESCRIPTION
The fact that MutateIn throws CasMismatchException is hidden in a Note, rather than the documented exceptions.