### PR TITLE
Correct `AnalyticsStatus` enum values

### DIFF
--- a/rfc/0057-sdk3-analytics.md
+++ b/rfc/0057-sdk3-analytics.md
@@ -173,13 +173,9 @@ The status needs to be decoded from the wire representation, which is in all cas
 enum AnalyticsStatus {
     RUNNING,
     SUCCESS,
-    ERRORS,
-    COMPLETED,
-    STOPPED,
     TIMEOUT,
-    CLOSED,
+    FAILED,
     FATAL,
-    ABORTED,
     UNKNOWN
 }
 ```
@@ -199,6 +195,8 @@ class AnalyticsWarning {
   * Initial Draft
 * April 30, 2020
   * Moved RFC to ACCEPTED state.
+* May 20, 2024 - Revision #2 (by Dimitris Christodoulou)
+  * Correct `AnalyticsStatus` enum values.
 
 # Signoff
 


### PR DESCRIPTION
The enum values for `AnalyticsStatus` were probably copied from the [REST API docs](https://docs.couchbase.com/server/current/analytics/rest-service.html#_query_responses) which are not right (they must have copied the query service status values). The correct values can be seen in the code [here](https://github.com/couchbase/asterixdb/blob/master/asterixdb/asterix-app/src/main/java/org/apache/asterix/api/http/server/AbstractQueryApiServlet.java#L38-L43).