### PR TITLE
CBD-6232: Support for configuring number of vBuckets for Magma buckets

### DIFF
--- a/rfc/0054-sdk3-management-apis.md
+++ b/rfc/0054-sdk3-management-apis.md
@@ -2330,7 +2330,7 @@ Nothing
 
 ### Throws
 
-* `BucketAlreadyExistsException` (HTTP 400 and content contains `Bucket with given name already exists`)
+* `BucketExistsException` (HTTP 400 and content contains `Bucket with given name already exists`)
 
 * `InvalidArgumentsException`
 
@@ -3678,6 +3678,11 @@ enum StorageBackend {
 
 * `StorageBackend` ([`StorageBackend`](#storagebackend)) - The storage type to use (note: Magma is EE only).
 
+* `NumVBuckets` (`int`) - The number of vbuckets the bucket should have.
+  * URL query field: `numVBuckets`.
+  * Must not be sent to the server if not set.
+  * The server accepts values 128 and 1024 when `StorageBackend` is `MAGMA` and 1024 for `COUCHSTORE`. SDKs must **not** have any client-side logic that validates this. It should be left up to ns-server. SDKs should simply ensure any error from ns_server is exposed to the user.
+
 * `HistoryRetentionCollectionDefault` (`bool`) - Whether to enable history retention on collections by default.
   * URL query field: `historyRetentionCollectionDefault`
   * If the SDK does not have the ability to differentiate between not set and `false` then a different type should be used instead, suggested:
@@ -4005,6 +4010,9 @@ interface ScopeSpec {
 * May 22nd, 2024 - Revision #26 (by Charles Dixon)
   * Specified that base64 vector search operations should raise `FeatureNotAvailableException` against clusters that do not support them.
 
+* March 25th, 2025 - Revision #27 (by Dimitris Christodoulou)
+  * `CreateBucket` can raise `BucketExistsException`, not `BucketAlreadyExistsException`. The latter does not exist in the latest revision of the [Error Handling RFC](0058-error-handling.md).
+  * Adding `NumVBuckets` to `BucketSettings`.
 
 # Signoff
 

--- a/rfc/0058-error-handling.md
+++ b/rfc/0058-error-handling.md
@@ -208,6 +208,8 @@ A Note on IDs: The IDs in this RFC are only for organisational purposes and MUST
   * It is unambiguously determined that the error was caused because of invalid arguments from the user
   * KV Subdoc:
     * 0xcb
+  * Management (ns_server):
+    * HTTP status 400 – if no more specific error type applies (e.g. BucketExists).
   * Notes
     * Usually only thrown directly when doing request arg validation
     * Also commonly used as a parent class for many service-specific exceptions (see below)
@@ -626,7 +628,7 @@ KV Code 0xc1
 
 ### 605 BucketExists
 
-* Raised from the bucket management API
+* Raised from the bucket management API (HTTP 400 and response body contains `Bucket with given name already exists`)
 
 ### 606 UserExists
 
@@ -755,6 +757,9 @@ KV Code 0xc1
 
 * April 1, 2021 - Revision #19 (by Michael Nitschinger)
   * Added the query DmlFailure and clarified the cas mismatch for query failures.
+* March 25, 2025 - Revision #20 (by Dimitris Christodoulou)
+  * ns-server management operations should raise `InvalidArgument` when the server responds with 400 HTTP status, if there is no more specific error type that applies.
+  * Clarify that `BucketExists` is raised in bucket manager when receiving 400 HTTP status and the response body contains `Bucket with given name already exists`, as is already prescribed by the [Management RFC](0054-sdk3-management-apis.md).
 
 ## Signoff
 


### PR DESCRIPTION
## Motivation

ns_server is adding support for Magma buckets with 128 vBuckets in Morpheus. We should support configuring the number of vbuckets that a Magma bucket should have via a new `BucketSettings` attribute.

## Changes

### Management RFC

* Add `NumVBuckets` to `BucketSettings` and clarify that SDKs should not perform any client-side validation on the value.
* Replace references to `BucketAlreadyExistsException` with `BucketExistsException`. The former does not exist in the accepted revision of the Error Handling RFC.

### Error Handling RFC

* If a 400 HTTP status is received in a ns_server management operation, that should be exposed as an `InvalidArgumentException`, unless a more specific exception type applies (e.g. `BucketExistsException`). This is already the behavior that has been implemented in most SDKs.