### PR TITLE
Allow setting both named & positonal parameters in query & analytics options

### DIFF
--- a/rfc/0056-sdk3-query.md
+++ b/rfc/0056-sdk3-query.md
@@ -79,7 +79,9 @@ QueryResult Query(string statement, [QueryOptions options]);
     * Sent in the JSON payload
       * For positional parameters as a json array under the "args" key
       * For named parameters directly in the JSON payload, but each named argument is prefixed with "$" if it doesn't already have the dollar prefix provided by the user
-    * Setting JsonArray or JsonObject overrides any previously set parameters
+      * The payload can include both positional and named parameters
+    * Setting JsonArray overrides any previously set _positional_ parameters
+    * Setting JsonObject overrides any previously set _named_ parameters
   * pipelineBatch(uint32) = undefined
     * Specifies pipeline batching characteristics
     * Sent in the JSON payload as "pipeline_batch" as a JSON String
@@ -280,7 +282,8 @@ class QueryWarning {
   * Change type of QueryMetadata.signature() from JsonObject to JsonValue.
 * Feb 6, 2025 - Revision #8 (by Dimitris Christodoulou)
   * Add IScope#Query API.
-
+* April 30, 2025 - Revision #9 (by Dimitris Christodoulou)
+  * Allow setting both positional and named parameters.
 
 # Signoff
 

--- a/rfc/0056-sdk3-query.md
+++ b/rfc/0056-sdk3-query.md
@@ -292,11 +292,12 @@ class QueryWarning {
 | Node.js    | Jared Casey    | July 19, 2023 | #6       |
 | Go         | Charles Dixon  | July 6, 2023  | #6       |
 | Connectors | David Nault    | July 6, 2023  | #6       |
-| PHP        | Sergey Avseyev | July 6, 2023  | #6       |
+| PHP        | Sergey Avseyev | May 7, 2025   | #9       |
 | Python     | Jared Casey    | July 19, 2023 | #6       |
 | Scala      | Graham Pople   | July 6, 2023  | #6       |
 | .NET       | Jeffry Morris  | July 21, 2023 | #6       |
 | Java       | David Nault    | July 6, 2023  | #6       |
 | Kotlin     | David Nault    | July 6, 2023  | #6       |
-| C          | Sergey Avseyev | July 6, 2023  | #6       |
-| Ruby       | Sergey Avseyev | July 6, 2023  | #6       |
+| C          | Sergey Avseyev | May 7, 2025   | #9       |
+| C++        | Sergey Avseyev | May 7, 2025   | #9       |
+| Ruby       | Sergey Avseyev | May 7, 2025   | #9       |

--- a/rfc/0057-sdk3-analytics.md
+++ b/rfc/0057-sdk3-analytics.md
@@ -62,7 +62,9 @@ IAnalyticsResult AnalyticsQuery(string statement, [AnalyticsOptions options]);
     * Sent in the JSON payload
       * For positional parameters as a JSON array under the "args" key
       * For named parameters directly in the JSON payload, but each named argument is prefixed with "$" if it doesn't already have the dollar prefix provided by the user
-    * Setting JsonArray or JsonObject overrides any previously set parameters
+      * The payload can include both positional and named parameters
+    * Setting JsonArray overrides any previously set _positional_ parameters
+    * Setting JsonObject overrides any previously set _named_ parameters
   * priority(boolean) = undefined(0)
     * Allows to give certain requests higher priority than others.
     * Sent on the wire in the HTTP header as "Analytics-Priority" a JSON Number. See the section on Priority in this RFC for more details how it should be encoded.
@@ -197,6 +199,8 @@ class AnalyticsWarning {
   * Moved RFC to ACCEPTED state.
 * May 20, 2024 - Revision #2 (by Dimitris Christodoulou)
   * Correct `AnalyticsStatus` enum values.
+* April 30, 2025 - Revision #3 (by Dimitris Christodoulou)
+  * Allow setting both positional and named parameters.
 
 # Signoff
 

--- a/rfc/0057-sdk3-analytics.md
+++ b/rfc/0057-sdk3-analytics.md
@@ -209,10 +209,11 @@ class AnalyticsWarning {
 | Node.js    | Brett Lawson        | Sept 27, 2019   | #1       |
 | Go         | Charles Dixon       | April 22, 2020  | #1       |
 | Connectors | David Nault         | April 29, 2020  | #1       |
-| PHP        | Sergey Avseyev      | April 22, 2020  | #1       |
+| PHP        | Sergey Avseyev      | May 7, 2025     | #3       |
 | Python     | Ellis Breen         | April 29, 2020  | #1       |
 | Scala      | Graham Pople        | Oct 18, 2019    | #1       |
 | .NET       | Jeffry Morris       | Sept 27, 2019   | #1       |
 | Java       | Michael Nitschinger | Sept 27, 2019   | #1       |
-| C          | Sergey Avseyev      | Sept 27, 2019   | #1       |
-| Ruby       | Sergey Avseyev      | Sept 27, 2019   | #1       |
+| C          | Sergey Avseyev      | May 7, 2025     | #3       |
+| C++        | Sergey Avseyev      | May 7, 2025     | #3       |
+| Ruby       | Sergey Avseyev      | May 7, 2025     | #3       |


### PR DESCRIPTION
The server allows setting both in the same request, so ~there's no reason we shouldn't allow that~ we should consider allowing that.