### PR TITLE
Update 0048-sdk3-bootstrapping.md for credential rotation

### DIFF
--- a/rfc/0048-sdk3-bootstrapping.md
+++ b/rfc/0048-sdk3-bootstrapping.md
@@ -200,7 +200,12 @@ A user should be able to supply a new Couchbase credential without having to res
 To support this, the SDK should allow replacing the Authenticator used by a `Cluster`.
 The recommended way to support this is for `Cluster` to have an instance method called `setAuthenticator` that takes the new authenticator as an argument.
 
-SDK implementers must take care to ensure it's safe to call `setAuthenticator` at any time, from any thread, and concurrently with an authentication operation.
+The `setAuthenticator` method should do the same validation as `Cluster.connect()`.
+Specifically, if the new authenticator requires TLS but TLS is not enabled, `setAuthenticator` should throw `InvalidArgumentException` or the idiomatic equivalent.
+
+The API reference documentation for `setAuthentictor` should clearly state that setting a new authenticator does not change the authentication status of existing connections.
+
+SDK implementers must ensure it is safe to call `setAuthenticator` from any thread at any time, including concurrently with an authentication operation.
 
 # Changelog
 


### PR DESCRIPTION
Add a section describing a proposed new ~`DynamicAuthenticator`~ `DelegatingAuthenticator` for periodically refreshing credentials.

UPDATE: The proposal has evolved; current version is to add a new `Cluster.setAuthenticator` method that lets a user replace the current authenticator with a new one. 