### PR TITLE
Eventing RFC: Add 'Resuming' function status

### DIFF
--- a/rfc/0062-eventing-management.md
+++ b/rfc/0062-eventing-management.md
@@ -891,10 +891,11 @@ enum EventingFunctionStatus {
 	Undeploying  
 	Paused  
 	Pausing  
+	Resuming
 }
 ```
 
-The EventingFunctionStatus mapping from JSON is specified as follows:
+The `EventingFunctionStatus` mapping from JSON is specified as follows:
 
 | State | JSON Property |
 | :---- | :---- |
@@ -904,6 +905,7 @@ The EventingFunctionStatus mapping from JSON is specified as follows:
 | Undeploying | “undeploying” |
 | Paused | “paused” |
 | Pausing | “pausing” |
+| Resuming | "resuming" |
 
 > [!NOTE]
 > The JSON representation for EventingFunctionState has a `“function_scope”` field, but this must not be part of the SDK representation. In the SDK, function scope is _contextual_, in other words, the scope is determined by the scope of the manager accessing the function.
@@ -1054,6 +1056,8 @@ The server does not provide a practical way to detect whether eventing function 
 
 # Changes
 
+* Revision \#16 (2026-04-28 \- Dimitris Christodoulou):
+  * Added `Resuming` enum value for `EventingFunctionStatus`.
 * Revision \#15 (2026-04-28 \- Dimitris Christodoulou):
   * Moved RFC to ACCEPTED state.
 * Revision \#14 (2024-03-18 \- David Nault):  

--- a/rfc/0062-eventing-management.md
+++ b/rfc/0062-eventing-management.md
@@ -892,6 +892,7 @@ enum EventingFunctionStatus {
 	Paused  
 	Pausing  
 	Resuming
+	Unknown
 }
 ```
 
@@ -906,6 +907,8 @@ The `EventingFunctionStatus` mapping from JSON is specified as follows:
 | Paused | “paused” |
 | Pausing | “pausing” |
 | Resuming | "resuming" |
+
+If the server returns a status that the SDK does not recognize, the status should be set to `Unknown`. This can be omitted if the SDK has a more idiomatic way to represent an unknown status. One example is Go, where the status is a string alias with constants for the known status values.
 
 > [!NOTE]
 > The JSON representation for EventingFunctionState has a `“function_scope”` field, but this must not be part of the SDK representation. In the SDK, function scope is _contextual_, in other words, the scope is determined by the scope of the manager accessing the function.


### PR DESCRIPTION
Eventing has added a `resuming` composite status (equivalent to our `EventingFunctionStatus`) in 8.0. We should also add it to the SDKs. This was first raised as an issue on the Go SDK, see [GOCBC-1791](https://jira.issues.couchbase.com/browse/GOCBC-1791).

[GOCBC-1791]: https://couchbasecloud.atlassian.net/browse/GOCBC-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ